### PR TITLE
Add unit tests for me.itzsomebody.radon.dictionaries.AlphaNumDictionary and CustomDictionary

### DIFF
--- a/src/test/java/me/itzsomebody/radon/dictionaries/AlphaNumDictionaryTest.java
+++ b/src/test/java/me/itzsomebody/radon/dictionaries/AlphaNumDictionaryTest.java
@@ -1,0 +1,60 @@
+package me.itzsomebody.radon.dictionaries;
+
+import me.itzsomebody.radon.utils.RandomUtils;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.mockito.Matchers.anyInt;
+
+@RunWith(PowerMockRunner.class)
+public class AlphaNumDictionaryTest {
+
+    @PrepareForTest({RandomUtils.class})
+    @Test
+    public void testRandomString() {
+        PowerMockito.mockStatic(RandomUtils.class);
+        PowerMockito.when(RandomUtils.getRandomInt(Math.abs(anyInt())))
+                .thenReturn(4);
+        Assert.assertEquals("EEE", new AlphaNumDictionary().randomString(3));
+    }
+
+    @PrepareForTest({RandomUtils.class})
+    @Test
+    public void testUniqueRandomString() {
+        PowerMockito.mockStatic(RandomUtils.class);
+        PowerMockito.when(RandomUtils.getRandomInt(Math.abs(anyInt())))
+                .thenReturn(4);
+
+        Assert.assertEquals("",
+                new AlphaNumDictionary().uniqueRandomString(-1));
+        Assert.assertEquals("EEE",
+                new AlphaNumDictionary().uniqueRandomString(3));
+    }
+
+    @Test
+    public void testNextUniqueString() {
+        Assert.assertEquals("A", new AlphaNumDictionary().nextUniqueString());
+    }
+
+    @Test
+    public void testLastUniqueString() {
+        Assert.assertNull(new AlphaNumDictionary().lastUniqueString());
+    }
+
+    @Test
+    public void testGetDictionaryName() {
+        Assert.assertEquals("alphanumeric",
+                new AlphaNumDictionary().getDictionaryName());
+    }
+
+    @Test
+    public void testCopy() {
+        Assert.assertEquals("alphanumeric",
+                new AlphaNumDictionary().copy().getDictionaryName());
+    }
+}

--- a/src/test/java/me/itzsomebody/radon/dictionaries/CustomDictionaryTest.java
+++ b/src/test/java/me/itzsomebody/radon/dictionaries/CustomDictionaryTest.java
@@ -1,0 +1,62 @@
+package me.itzsomebody.radon.dictionaries;
+
+import me.itzsomebody.radon.utils.RandomUtils;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.mockito.Matchers.anyInt;
+
+@RunWith(PowerMockRunner.class)
+public class CustomDictionaryTest {
+
+    @PrepareForTest({RandomUtils.class})
+    @Test
+    public void testRandomString() {
+        PowerMockito.mockStatic(RandomUtils.class);
+        PowerMockito.when(RandomUtils.getRandomInt(Math.abs(anyInt())))
+                .thenReturn(4);
+        Assert.assertEquals("aaa",
+                new CustomDictionary("foobar").randomString(3));
+    }
+
+    @PrepareForTest({RandomUtils.class})
+    @Test
+    public void testUniqueRandomString() {
+        PowerMockito.mockStatic(RandomUtils.class);
+        PowerMockito.when(RandomUtils.getRandomInt(Math.abs(anyInt())))
+                .thenReturn(4);
+
+        Assert.assertEquals("",
+                new CustomDictionary("foobar").uniqueRandomString(-1));
+        Assert.assertEquals("aaa",
+                new CustomDictionary("foobar").uniqueRandomString(3));
+    }
+
+    @Test
+    public void testNextUniqueString() {
+        Assert.assertEquals("f",
+                new CustomDictionary("foobar").nextUniqueString());
+    }
+
+    @Test
+    public void testLastUniqueString() {
+        Assert.assertNull(new CustomDictionary("foobar").lastUniqueString());
+    }
+
+    @Test
+    public void testGetDictionaryName() {
+        Assert.assertEquals("foobar",
+                new CustomDictionary("foobar").getDictionaryName());
+    }
+
+    @Test
+    public void testCopy() {
+        Assert.assertEquals("foobar",
+                new CustomDictionary("foobar").copy().getDictionaryName());
+    }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `me.itzsomebody.radon.dictionaries.AlphaNumDictionary` and `CustomDictionary` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.